### PR TITLE
Various tweaks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,11 @@ task :compile do
   sh "bundle exec nanoc compile"
 end
 
+desc "View the site at localhost:3000."
+task :view do
+  sh "bundle exec nanoc view"
+end
+
 desc "Write it out to secretchronicles.de."
 task :deploy => :compile do
   sh "rsync -hrE --progress output/ quintus@alexandria.secretchronicles.de:/srv/http/mainsite/"

--- a/content/stylesheets/default.css
+++ b/content/stylesheets/default.css
@@ -33,6 +33,7 @@ body {
 	padding: 15px ;
     position: relative;
 	color:white;
+    cursor: pointer;
 }
 #navbar li:hover {
 	background-color: purple;

--- a/layouts/_head_en.erb
+++ b/layouts/_head_en.erb
@@ -2,21 +2,21 @@
   <h1><a href="/en"><img class="logo" src="/assets/logo.png" alt="The Secret Chronicles"></a></h1>
 </div>
 <ul id="navbar">
-  <li> <a href="/en">Home</a></li>
-  <li> <a href="/en/screenshots">Screenshots</a></li>
-  <li> <a href="/en/news">News</a></li>
-  <li> <a href="/en/download">Download</a></li>
-  <li> <a href="https://github.com/Secretchronicles/TSC">Github</a></li>
-  <li> <a href="https://github.com/Secretchronicles/TSC/issues/">Bugs</a></li>
-  <li> <a href="http://forum.secretchronicles.de/forums">Forum</a> </li>
-  <li> <a href="http://lists.secretchronicles.de/">Mailinglist</a></li>
-  <li> <a href="http://wiki.secretchronicles.de/">Wiki</a></li>
-  <li> <a href="/en/documentation">Docs</a></li>
-  <li> <a href="http://chatlogs.secretchronicles.de/">IRC Logs</a></li>
+  <a href="/en"><li>Home</li></a>
+  <a href="/en/screenshots"><li>Screenshots</li></a>
+  <a href="/en/news"><li>News</li></a>
+  <a href="/en/download"><li>Download</li></a>
+  <a href="https://github.com/Secretchronicles/TSC"><li>Github</li></a>
+  <a href="https://github.com/Secretchronicles/TSC/issues/"><li>Bugs</li></a>
+  <a href="http://forum.secretchronicles.de/forums"><li>Forum</li></a>
+  <a href="http://lists.secretchronicles.de/"><li>Mailinglist</li></a>
+  <a href="http://wiki.secretchronicles.de/"><li>Wiki</li></a>
+  <a href="/en/documentation"><li>Docs</li></a>
+  <a href="http://chatlogs.secretchronicles.de/"><li>IRC Logs</li></a>
   <li>Language
     <ul>
-      <li><a href="/fi"><img class="language" alt="Finnish" src="/assets/flags/fi.png"> Finnish</a></li>
-      <li><a href="/en"><img class="language" alt="English" src="/assets/flags/en.png"> English</a></li>
+      <a href="/fi"><li><img class="language" alt="Finnish" src="/assets/flags/fi.png"> Finnish</li></a>
+      <a href="/en"><li><img class="language" alt="English" src="/assets/flags/en.png"> English</li></a>
     </ul>
   </li>
 </ul>


### PR DESCRIPTION
- `8ceedec` makes the entire darkened `area in the navbars clickable, instead of just the text.
- `b0ac801` causes all the navbar areas (most specifically the "Language" one) to have the cursor as a pointer. Looks much more consistent.
- `ddca505` adds a little helper task that I found quite helpful.
