### PR TITLE
Fix Building issue caused by index.html

### DIFF
--- a/Rules
+++ b/Rules
@@ -15,6 +15,8 @@ require "time"
 #   item, use the pattern “/about/*/”; “/about/*” will also select the parent,
 #   because “*” matches zero or more characters.
 
+
+
 LANGUAGES = Dir["content/*"].map{|str| File.basename(str)}.select{|str| str.chars.count == 2}
 
 # Generate the RSS feeds
@@ -66,6 +68,10 @@ LANGUAGES.each do |lang|
     layout "default_#{lang}"
   end
 
+compile '/' do
+    end
+
+
   compile "/#{lang}/news/" do
     filter :erb
     layout "default_#{lang}"
@@ -116,6 +122,10 @@ LANGUAGES.each do |lang|
   route "/#{lang}/feed/" do
     "/#{lang}/feed.atom"
   end
+
+  route "/" do
+    "/index.html"
+end
 
   route "/#{lang}/pages/*/" do
     "/#{lang}/" + item.identifier.split("/")[3] + "/index.html"


### PR DESCRIPTION
This should fix the issue with the site not building, but I don't have the guts to push it to the main site without someone else testing it as well. 
Xet7 added a Index.html file that didn't have any Rules set up for it, so Nanoc was freaking out. I'm not sure if what I did was a proper for, so if someone else can test it or merge it after they test it I would really appreciate it. I can merge it if need be. 

Thanks!