### PR TITLE
Change Commercial Support page

### DIFF
--- a/content/en/pages/support.md
+++ b/content/en/pages/support.md
@@ -1,19 +1,38 @@
 ---
-title: Commercial Support
+title: Support TSC
 ---
 
-Worldwide: TSC Team
--------------------
+TSC is a freetime project of several artists, programmers, and many
+more people. If you want to support TSC by participating, please go to
+the [community](/en/community) page. If you want to spend money on the
+project, please read on.
 
-* Support for installing the TSC game
+TSC as such is not sustainable. Some team members however are
+professional freelance coders outside of TSC, and if payed, they can
+devote some of their work time to TSC. The below options allow for
+such arrangements; think of them as a bounty system.
+
+Received payments without specific directions will be used to:
+
+* Implement features, fixes etc
+* Do contests for great art and music in the game
+* Organise physical meetings of the developers (travel expenses)
+* Buy hardware for testing the game, for backups, or anything else
+  TSC game related
+* Saving for unexpected costs
+
+You can include specific directions with your payment:
+
 * Feature and Fix development for the TSC game
 * Creating packages for some Linux distros on some CPUs
   where packages do not exist yet
 
-Email: [support@secretchronicles.org](mailto:support@secretchronicles.org)
+Money received with such directions will only be used according to
+them. Please write to [support@secretchronicles.org](mailto:support@secretchronicles.org)
+if you want to include such directions.
 
 1) Pre-payment: Fastest to send with smallest fees
------------------------------------------------
+--------------------------------------------------
 
 Send with [TransferWise](https://transferwise.com) to
 [support@secretchronicles.org](mailto:support@secretchronicles.org)
@@ -73,20 +92,10 @@ Required info to send to Email [support@secretchronicles.org](mailto:support@sec
 Transparency
 ------------
 
-TSC is a freetime project of several artists, programmers, and many
-more people. Commercial Support payments will be used to:
-
-* Implement features, fixes etc which have been ordered
-* Do contests for great art and music in the game
-* Organise physical meetings of the developers (travel expenses)
-* Buy hardware for testing the game, for backups, or anything else
-  TSC game related
-* Saving for unexpected costs
-
 The project lead maintains maximum transparency regarding the
-money that is received from Commercial Support with reports at [forum][1],
+money that is received with reports at [forum][1],
 and the team decides as a whole about how any received money is to
-be spent. Be assured we are very grateful to all
-Commercial Support customers to advance the TSC game development.
+be spent. Be assured we are very grateful for everyone who helps
+to advance the TSC game development.
 
 [1]: https://lists.secretchronicles.org/hyperkitty/list/tsc-devel@lists.secretchronicles.org/

--- a/content/en/pages/support.md
+++ b/content/en/pages/support.md
@@ -8,7 +8,7 @@ the [community](/en/community) page. If you want to spend money on the
 project, please read on.
 
 TSC as such is not sustainable. Some team members however are
-professional freelance coders outside of TSC, and if payed, they can
+professional freelance coders outside of TSC, and if paid, they can
 devote some of their work time to TSC. The below options allow for
 such arrangements; think of them as a bounty system.
 

--- a/layouts/_head_en.erb
+++ b/layouts/_head_en.erb
@@ -10,7 +10,7 @@
   <li><a href="/en/community">Community and Contributing</a></li>
   <li><a href="https://wiki.secretchronicles.org/">Wiki</a></li>
   <li><a href="/en/documentation">Docs</a></li>
-  <li><a href="/en/support">Commercial Support</a></li>
+  <li><a href="/en/support">Support TSC</a></li>
   <li><a>Language</a>
     <ul>
       <li><a href="/fi"><img class="flag" alt="Finnish" src="/assets/flags/fi.png"/><br />Finnish</a></li>


### PR DESCRIPTION
First, thanks to @xet7 for setting up a money infrastructure for TSC. I have some suggestions for the exact wording, though, which I hereby publish for discussion.

I've changed the following things.

* Rename "Commercial Support" to "Support TSC". It just sounds incorrect to me to name it "commercial". TSC is not a commercial project, and I don't want that the impression arises. I understand that xet7 doesn't want to name it "donations", so I suggest "Support TSC" instead.
* Likewise, all appearences of "commercial" were stripped from the page text.
* I've written a sensible preamble that underlines the freetime character of TSC.
* I've made the scope of the two lists at the beginning more clear (payments with direction and payments without). I think this wasn't clear from the before text version.
* The payment direction "support for installing the TSC game" has been removed. This is not something the TSC project as a whole benefits from (because no code change or otherwise team activity results). It's only profitable for the person who gets payed for that. xet7, if you insist on this option, I can include a new paragraph that points out that you provide that.

Everyone: please review. This is something important for the project as a whole, and I'd like to have it properly set up before the 2.1.0 release.